### PR TITLE
Use rd_kafka_destroy_flags

### DIFF
--- a/src/kafka_handle_base.cpp
+++ b/src/kafka_handle_base.cpp
@@ -48,7 +48,7 @@ namespace cppkafka {
 const milliseconds KafkaHandleBase::DEFAULT_TIMEOUT{1000};
 
 KafkaHandleBase::KafkaHandleBase(Configuration config) 
-: timeout_ms_(DEFAULT_TIMEOUT), config_(move(config)), handle_(nullptr, nullptr) {
+: timeout_ms_(DEFAULT_TIMEOUT), config_(move(config)), handle_(nullptr, handle_deleter()) {
     auto& maybe_config = config_.get_default_topic_configuration();
     if (maybe_config) {
         maybe_config->set_as_opaque();
@@ -182,7 +182,7 @@ void KafkaHandleBase::yield() const {
 }
 
 void KafkaHandleBase::set_handle(rd_kafka_t* handle) {
-    handle_ = HandlePtr(handle, &rd_kafka_destroy);
+    handle_ = HandlePtr(handle, handle_deleter());
 }
 
 Topic KafkaHandleBase::get_topic(const string& name, rd_kafka_topic_conf_t* conf) {


### PR DESCRIPTION
Use rd_kafka_destroy_flags with RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE instead of rd_kafka_destroy.

https://github.com/ClickHouse/ClickHouse/pull/10910
https://github.com/ClickHouse/ClickHouse/issues/7260