### PR TITLE
Fix crash in get_member_id() if client group is not initialized

### DIFF
--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -241,6 +241,8 @@ TopicPartitionList Consumer::get_assignment() const {
 
 string Consumer::get_member_id() const {
     char* memberid_ptr = rd_kafka_memberid(get_handle());
+    if (memberid_ptr == nullptr)
+        return string();
     string memberid_string = memberid_ptr;
     rd_kafka_mem_free(nullptr, memberid_ptr);
     return memberid_string;


### PR DESCRIPTION
Since in this case rd_kafka_memberid() return NULL, and std::string cannot be constructed from NULL [1].

  [1]: https://github.com/llvm/llvm-project/blob/fe51d8ae5772626ef8237c33e0911695cf4f07db/libcxx/include/string#L1051-L1055

Refs: https://github.com/ClickHouse/ClickHouse/issues/80674#issuecomment-2902812207
Upstream: https://github.com/mfontanini/cppkafka/pull/320