### PR TITLE
Catch exceptions from assign/unassign in handle_rebalance

### DIFF
--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -314,15 +314,41 @@ void Consumer::handle_rebalance(rd_kafka_resp_err_t error,
                                 TopicPartitionList& topic_partitions) {
     if (error == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
         CallbackInvoker<AssignmentCallback>("assignment", assignment_callback_, this)(topic_partitions);
-        assign(topic_partitions);
+        try {
+            assign(topic_partitions);
+        }
+        catch (const HandleException& e) {
+            // rd_kafka_assign() can time out when the consumer-group
+            // thread is blocked (e.g. broker unreachable during
+            // rebalance).  This is called from a C callback
+            // (rebalance_proxy) so we must not let the exception
+            // escape.  Route the error through the rebalance-error
+            // callback instead.
+            CallbackInvoker<RebalanceErrorCallback>(
+                "rebalance error", rebalance_error_callback_, this)(
+                    e.get_error());
+        }
     }
     else if (error == RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS) {
         CallbackInvoker<RevocationCallback>("revocation", revocation_callback_, this)(topic_partitions);
-        unassign();
+        try {
+            unassign();
+        }
+        catch (const HandleException& e) {
+            CallbackInvoker<RebalanceErrorCallback>(
+                "rebalance error", rebalance_error_callback_, this)(
+                    e.get_error());
+        }
     }
     else {
         CallbackInvoker<RebalanceErrorCallback>("rebalance error", rebalance_error_callback_, this)(error);
-        unassign();
+        try {
+            unassign();
+        }
+        catch (const HandleException&) {
+            // Best-effort unassign during error handling; ignore
+            // failures since we already reported the original error.
+        }
     }
 }
 

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -321,12 +321,22 @@ void Consumer::handle_rebalance(rd_kafka_resp_err_t error,
             // rd_kafka_assign() can time out when the consumer-group
             // thread is blocked (e.g. broker unreachable during
             // rebalance).  This is called from a C callback
-            // (rebalance_proxy) so we must not let the exception
-            // escape.  Route the error through the rebalance-error
-            // callback instead.
+            // (rebalance_proxy) so we must not let any exception
+            // escape — that would be undefined behavior.  Route the
+            // error through the rebalance-error callback instead.
             CallbackInvoker<RebalanceErrorCallback>(
                 "rebalance error", rebalance_error_callback_, this)(
                     e.get_error());
+        }
+        catch (const std::exception&) {
+            CallbackInvoker<RebalanceErrorCallback>(
+                "rebalance error", rebalance_error_callback_, this)(
+                    RD_KAFKA_RESP_ERR__FAIL);
+        }
+        catch (...) {
+            CallbackInvoker<RebalanceErrorCallback>(
+                "rebalance error", rebalance_error_callback_, this)(
+                    RD_KAFKA_RESP_ERR__FAIL);
         }
     }
     else if (error == RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS) {
@@ -339,13 +349,23 @@ void Consumer::handle_rebalance(rd_kafka_resp_err_t error,
                 "rebalance error", rebalance_error_callback_, this)(
                     e.get_error());
         }
+        catch (const std::exception&) {
+            CallbackInvoker<RebalanceErrorCallback>(
+                "rebalance error", rebalance_error_callback_, this)(
+                    RD_KAFKA_RESP_ERR__FAIL);
+        }
+        catch (...) {
+            CallbackInvoker<RebalanceErrorCallback>(
+                "rebalance error", rebalance_error_callback_, this)(
+                    RD_KAFKA_RESP_ERR__FAIL);
+        }
     }
     else {
         CallbackInvoker<RebalanceErrorCallback>("rebalance error", rebalance_error_callback_, this)(error);
         try {
             unassign();
         }
-        catch (const HandleException&) {
+        catch (...) {
             // Best-effort unassign during error handling; ignore
             // failures since we already reported the original error.
         }


### PR DESCRIPTION
## Summary

`handle_rebalance` is called from `rebalance_proxy`, a C callback registered with librdkafka. The `assign()` and `unassign()` calls inside it can now throw `HandleException` when `rd_kafka_assign()` times out (see ClickHouse/librdkafka#18) instead of blocking forever. Throwing from a C callback is undefined behavior.

Wrap `assign()` and `unassign()` in try/catch and route timeout errors through the existing `rebalance_error_callback_`, which the application already handles.